### PR TITLE
Escape username before building ldap filter.

### DIFF
--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -51,7 +51,8 @@ module OmniAuth
 
       def filter adaptor
         if adaptor.filter and !adaptor.filter.empty?
-          Net::LDAP::Filter.construct(adaptor.filter % {username: @options[:name_proc].call(request['username'])})
+          escaped_username = Net::LDAP::Filter.escape(@options[:name_proc].call(request['username']))
+          Net::LDAP::Filter.construct(adaptor.filter % {username: escaped_username})
         else
           Net::LDAP::Filter.eq(adaptor.uid, @options[:name_proc].call(request['username']))
         end


### PR DESCRIPTION
Certain characters are valid for usernames, but must be escaped before a filter
is built with the username. Otherwise, these chars get interpreted as special
filter chars which can do anything from break the filter creation to enable an
injection attack to build a malicious filter. These special chars include '*',
'(', ')', and '\'.

ruby-net-ldap already has escaping implemented, but the escape method isn't
currently called because omniauth-ldap passes a full filter string in. The
escape method needs to be called before omniauth-ldap interpolates the user
supplied username into the configured filter template.
This is only relevant when there is a filter template specified.

See RFC 2254, "String Representation of LDAP" for more information.